### PR TITLE
Address melpa comments.

### DIFF
--- a/hyperkitty.el
+++ b/hyperkitty.el
@@ -106,7 +106,7 @@ Argument MLIST the mailinglist object from the API to print."
   (let* ((mlist (hyperkitty--choose-mailinglist))
          (base-url (assoc-default mlist hyperkitty-mlists))
          (threads-url (hyperkitty-threads-url base-url mlist)))
-    (hyperkitty--get-json threads-url (apply-partially 'print-threads-table mlist base-url))))
+    (hyperkitty--get-json threads-url (apply-partially #'hyperkitty--print-threads-table mlist base-url))))
 
 
 (defun hyperkitty ()
@@ -117,9 +117,6 @@ variable and let's user choose one of the mailing list and then
 opens a new buffer with a list of threads for that MailingList."
   (interactive)
   (hyperkitty--choose-mailinglist-and-get-threads))
-
-(provide 'hyperkitty)
-
 
 ;; threads related.
 
@@ -133,7 +130,7 @@ more threads and print the [More Threads] button.")
 (defvar hyperkitty-threads-mode-map nil "Keymap for 'hyperkitty-threads-mode-map'.")
 (progn
   (setq hyperkitty-threads-mode-map (make-sparse-keymap))
-  (define-key hyperkitty-threads-mode-map (kbd "<RET>") 'get-thread-emails))
+  (define-key hyperkitty-threads-mode-map (kbd "<RET>") #'hyperkitty--get-thread-emails))
 
 
 (define-derived-mode hyperkitty-threads-mode tabulated-list-mode "hyperkitty-threads-mode"
@@ -169,13 +166,12 @@ Argument RESPONSE HTTP response for MLIST's threads."
   (interactive)
   (pop-to-buffer (format "*%s*" mlist) nil)
   (hyperkitty-threads-mode)
-  (make-local-variable 'hyperkitty-page-num)
-  (make-local-variable 'hyperkitty-current-mlist)
-  (make-local-variable 'hyperkitty-base-url)
-  (setq hyperkitty-page-num 1)
-  (setq hyperkitty-current-mlist mlist)
-  (setq hyperkitty-base-url base-url)
-  (setq tabulated-list-entries (hyperkitty--get-threads-response-with-more-button response))
+  (dolist (var '(hyperkitty-page-num hyperkitty-current-mlist hyperkitty-base-url))
+    (make-local-variable var))
+  (setq hyperkitty-page-num 1
+        hyperkitty-current-mlist mlist
+        hyperkitty-base-url base-url
+        tabulated-list-entries (hyperkitty--get-threads-response-with-more-button response))
   (tabulated-list-print t))
 
 
@@ -333,18 +329,12 @@ Argument BUTTON Button object for this handler."
       (outline-show-entry)
     (outline-hide-entry)))
 
-(defun hyperkitty-kill-current-buffer ()
-  "Kill the current buffer."
-  (interactive)
-  (kill-buffer (current-buffer)))
-
-
 (defvar hyperkitty-thread-emails-mode-map nil "Keymap for 'hyperkitty-thread-emails-mode'.")
 (progn
   (setq hyperkitty-thread-emails-mode-map (make-sparse-keymap))
-  (define-key hyperkitty-thread-emails-mode-map (kbd "<RET>") 'hyperkitty-outline-toggle)
-  (define-key hyperkitty-thread-emails-mode-map (kbd "TAB") 'hyperkitty-outline-toggle)
-  (define-key hyperkitty-thread-emails-mode-map (kbd "q") 'hyperkitty-kill-current-buffer))
+  (define-key hyperkitty-thread-emails-mode-map (kbd "<RET>") #'hyperkitty-outline-toggle)
+  (define-key hyperkitty-thread-emails-mode-map (kbd "TAB") #'hyperkitty-outline-toggle)
+  (define-key hyperkitty-thread-emails-mode-map (kbd "q") #'kill-buffer-and-window))
 
 
 (setq email-highlights
@@ -384,5 +374,8 @@ Argument THREADS-URL URL to the current thread."
 (defun hyperkitty-get-base-url ()
   "Prompt User to get the base URL for hyperkitty."
   (read-string "Enter Hyperkitty URL:"))
+
+
+(provide 'hyperkitty)
 
 ;;; hyperkitty.el ends here

--- a/hyperkitty.el
+++ b/hyperkitty.el
@@ -166,8 +166,6 @@ Argument RESPONSE HTTP response for MLIST's threads."
   (interactive)
   (pop-to-buffer (format "*%s*" mlist) nil)
   (hyperkitty-threads-mode)
-  (dolist (var '(hyperkitty-page-num hyperkitty-current-mlist hyperkitty-base-url))
-    (make-local-variable var))
   (setq hyperkitty-page-num 1
         hyperkitty-current-mlist mlist
         hyperkitty-base-url base-url

--- a/hyperkitty.el
+++ b/hyperkitty.el
@@ -3,12 +3,16 @@
 ;; Copyright (c) 2020 Abhilash Raj
 ;;
 ;; Author: Abhilash Raj <maxking@asynchronous.in>
-;; URL: http://github.com/maxking/hyperkitty.el
+;; URL: https://github.com/maxking/hyperkitty.el
 ;; Version: 0.0.1
 ;; Keywords: mail hyperkitty mailman
 ;; Package-Requires: ((request "0.3.2") (emacs "25.1"))
 ;; Prefix: hyperkitty
 ;; Separator: -
+
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; License: Apache-2.0
 
 
 ;;; Commentary:
@@ -75,7 +79,7 @@ the list of MailingList."
     (insert (format "URL: %s, Status: %s, Data: %s"
                     (request-response-url response)
                     (request-response-status-code response)
-                    (mapcar 'hyperkitty--print-mailinglist (hyperkitty--get-response-entries response))))))
+                    (mapcar #'hyperkitty--print-mailinglist (hyperkitty--get-response-entries response))))))
 
 
 (defun hyperkitty--print-mailinglist (mlist)
@@ -119,10 +123,10 @@ This affects how is this package able to recoginize if there are
 more threads and print the [More Threads] button.")
 
 ;; Keyboard map for hyperkitty-threads-mode.
-(defvar hyperkitty-threads-mode-map nil "Keymap for 'hyperkitty-threads-mode-map'.")
-(progn
-  (setq hyperkitty-threads-mode-map (make-sparse-keymap))
-  (define-key hyperkitty-threads-mode-map (kbd "<RET>") #'hyperkitty--get-thread-emails))
+(defvar hyperkitty-threads-mode-map
+  (let (map (make-sparse-keymap))
+    (define-key hyperkitty-threads-mode-map (kbd "<RET>") #'hyperkitty--get-thread-emails))
+  "Keymap for 'hyperkitty-threads-mode-map'")
 
 
 (define-derived-mode hyperkitty-threads-mode tabulated-list-mode "hyperkitty-threads-mode"
@@ -186,7 +190,7 @@ Argument RESPONSE HTTP json response to get threads from."
 Also, add a [More Threads] button in the last line.
 Argument RESPONSE HTTP json response for threads."
   (let ((threads (hyperkitty--get-threads-response response)))
-    (message (format "Length of threads is: %s and page-size is: %s" (length threads) hyperkitty-page-size))
+    (message "Length of threads is: %s and page-size is: %s" (length threads) hyperkitty-page-size)
     (if (= (length threads) hyperkitty-page-size)
         (cons
          (list "more-threads"
@@ -312,13 +316,12 @@ Argument BUTTON Button object for this handler."
       (outline-show-entry)
     (outline-hide-entry)))
 
-(defvar hyperkitty-thread-emails-mode-map nil "Keymap for 'hyperkitty-thread-emails-mode'.")
-(progn
-  (setq hyperkitty-thread-emails-mode-map (make-sparse-keymap))
-  (define-key hyperkitty-thread-emails-mode-map (kbd "<RET>") #'hyperkitty-outline-toggle)
-  (define-key hyperkitty-thread-emails-mode-map (kbd "TAB") #'hyperkitty-outline-toggle)
-  (define-key hyperkitty-thread-emails-mode-map (kbd "q") #'kill-buffer-and-window))
-
+(defvar hyperkitty-thread-emails-mode-map
+  (let (map (make-sparse-keymap))
+    (define-key map (kbd "<RET>") #'hyperkitty-outline-toggle)
+    (define-key map (kbd "TAB") #'hyperkitty-outline-toggle)
+    (define-key map (kbd "q") #'kill-buffer-and-window))
+  "Keymap for 'hyperkitty-thread-emails-mode'.")
 
 (setq email-highlights
       '(("From:\\|Date:\\|Subject:\\|Message-ID:\\|Attachments:" . font-lock-keyword-face)
@@ -353,7 +356,7 @@ Argument THREADS-URL URL to the current thread."
 
 (defun hyperkitty-get-base-url ()
   "Prompt User to get the base URL for hyperkitty."
-  (read-string "Enter Hyperkitty URL:"))
+  (read-string "Enter Hyperkitty URL: "))
 
 
 (provide 'hyperkitty)

--- a/hyperkitty.el
+++ b/hyperkitty.el
@@ -37,10 +37,8 @@
 
 (defvar hyperkitty-mlists nil
   "A list of MailingLists configured for the current instance.
-
 Each entry in this list is a tuple, one the posting address for
 the MailingList and other is the Base URL of the server.
-
 For example:
 
     (setq
@@ -51,7 +49,6 @@ For example:
 ;;; HTTP fetch utilities.
 (defun hyperkitty--get-json (url success-func)
   "Call the given `URL' and call provided call function on success.
-
 We currently don't have a good error handling.
 Argument URL to fetch json response for.
 Argument SUCCESS-FUNC Response handler for the json from URL."
@@ -65,7 +62,6 @@ Argument SUCCESS-FUNC Response handler for the json from URL."
 
 (defun hyperkitty--get-response-entries (response)
   "Get entries from the paginated response.
-
 Argument RESPONSE HTTP response to get object entries from."
   (assoc-default 'results (request-response-data response)))
 
@@ -73,7 +69,6 @@ Argument RESPONSE HTTP response to get object entries from."
 ;;; Test function to print all the mailing list.
 (defun hyperkitty-print-mailinglist-response (response)
   "Print each element MailingLists from the RESPONSE.
-
 Handler for HTTP response for all the lists API.  It simply prints
 the list of MailingList."
   (with-current-buffer "*scratch*"
@@ -85,7 +80,6 @@ the list of MailingList."
 
 (defun hyperkitty--print-mailinglist (mlist)
   "Get an association lists and prints the details to buffer.
-
 Argument MLIST the mailinglist object from the API to print."
   (format "\nName: %s \nAddress: %s \nDescription: %s \n"
           (assoc-default 'display_name mlist)
@@ -111,7 +105,6 @@ Argument MLIST the mailinglist object from the API to print."
 
 (defun hyperkitty ()
   "This is the primary entrypoint to hyperkitty.el.
-
 It fetches the Hyperkitty API from the `hyperkitty-base-url'
 variable and let's user choose one of the mailing list and then
 opens a new buffer with a list of threads for that MailingList."
@@ -122,7 +115,6 @@ opens a new buffer with a list of threads for that MailingList."
 
 (defvar hyperkitty-page-size 25
   "Page size for Hyperkitty's pagination.
-
 This affects how is this package able to recoginize if there are
 more threads and print the [More Threads] button.")
 
@@ -135,7 +127,6 @@ more threads and print the [More Threads] button.")
 
 (define-derived-mode hyperkitty-threads-mode tabulated-list-mode "hyperkitty-threads-mode"
   "Major mode for MailingList threads.
-
 It presents a list of threads in a tabular format with three
 columns, Subject, Reply and Last Active date.
 "
@@ -157,7 +148,6 @@ columns, Subject, Reply and Last Active date.
 
 (defun hyperkitty--print-threads-table (mlist base-url response)
   "Print the whole threads table for a given MailingList.
-
 Create a new buffer, named after the MailingList and switch to
 `hyperkitty-threads-mode'.  Finally, display all the threads from the RESPONSE.
 Argument MLIST Posting address for the MailingList.
@@ -175,7 +165,6 @@ Argument RESPONSE HTTP response for MLIST's threads."
 
 (defun hyperkitty--get-threads-response (response)
   "Given a HTTP RESPONSE, return a list that tablulated-list-mode.
-
 It expects data in the form of:
 \(<thread-url> [(<subject> <date>)
                (<subject2> <date2>)
@@ -195,7 +184,6 @@ Argument RESPONSE HTTP json response to get threads from."
 (defun hyperkitty--get-threads-response-with-more-button (response)
   "Get the list of threads from the response.
 Also, add a [More Threads] button in the last line.
-
 Argument RESPONSE HTTP json response for threads."
   (let ((threads (hyperkitty--get-threads-response response)))
     (message (format "Length of threads is: %s and page-size is: %s" (length threads) hyperkitty-page-size))
@@ -243,7 +231,6 @@ Argument RESPONSE for the json response for more threads."
 
 (defun hyperkitty--print-emails-response (subject response)
   "Print all the Emails of a thread in a new Buffer.
-
 Create a new buffer, named after the SUBJECT of the email and
 print all the emails in that new buffer.  Each Email's content is
 fetched individual since the entries only contain the metadata
@@ -264,7 +251,6 @@ Argument RESPONSE HTTP response to print in the current buffer."
 
 (defun hyperkitty--print-email (email)
   "Fetch and print a single EMAIL to the current buffer.
-
 Given a metadata object for Email, fetch the actual contents of
 the Email and print it to the current buffer."
   (hyperkitty--get-json
@@ -304,8 +290,7 @@ the Email and print it to the current buffer."
 
 
 (defun hyperkitty--attachments (url _button)
-  "Hyperkitty fetch the attachments.
-
+  "Fetch the attachments in a browser.
 This exists as a separate function so that we can use
 `apply-partially' to create a function that acts like a click
 handler.  Using this in a lambda function would evaluate it before
@@ -342,7 +327,6 @@ Argument BUTTON Button object for this handler."
 ;; url stuff.
 (defun hyperkitty-lists-url (base-url)
   "Get a list of all MailingLists from API.
-
 Currently, this does not handle pagination and simply returns the
 default URL without pagination.
 Argument BASE-URL Base URL for Hyperkitty instnace."
@@ -350,7 +334,6 @@ Argument BASE-URL Base URL for Hyperkitty instnace."
 
 (defun hyperkitty-threads-url (base-url mlist &optional page)
   "Get a list of all threads for a MailingList.
-
 Currently, this does not handle pagination and simply returns the
 default URL without pagination.
 Argument BASE-URL Base URL for hyperkitty instance.
@@ -363,7 +346,6 @@ Optional argument PAGE The page number for the paginated response."
 
 (defun hyperkitty-thread-emails-url (threads-url)
   "Get all emails for the given thread URL.
-
 This does not handle pagination currently.
 Argument THREADS-URL URL to the current thread."
   (concat threads-url "/emails"))

--- a/hyperkitty.el
+++ b/hyperkitty.el
@@ -75,7 +75,7 @@ the list of MailingList."
     (insert (format "URL: %s, Status: %s, Data: %s"
                     (request-response-url response)
                     (request-response-status-code response)
-                    (dolist #'hyperkitty--print-mailinglist (hyperkitty--get-response-entries response))))))
+                    (mapcar 'hyperkitty--print-mailinglist (hyperkitty--get-response-entries response))))))
 
 
 (defun hyperkitty--print-mailinglist (mlist)

--- a/hyperkitty.el
+++ b/hyperkitty.el
@@ -80,7 +80,7 @@ the list of MailingList."
     (insert (format "URL: %s, Status: %s, Data: %s"
                     (request-response-url response)
                     (request-response-status-code response)
-                    (mapcar #'hyperkitty--print-mailinglist (hyperkitty--get-response-entries response))))))
+                    (dolist #'hyperkitty--print-mailinglist (hyperkitty--get-response-entries response))))))
 
 
 (defun hyperkitty--print-mailinglist (mlist)


### PR DESCRIPTION
Address comments from melpa reviews.
    
- Use https:// for URLs.
- Don't use top-level `define-key`.
- Use `#'` for quoting functions.
- Add License and SPDX-License-Identifier.
- Add empty space after prompt for read-string.
- Don't use `format` for `message` since it already is format string.
﻿- Several changes.
- No need to create local var since they are already created.
- Use dolist instead of mapcar.
- Remove empty lines in docstrings.
- Use mapcar since dolist causes some errors.
- Address comments from melpa reviews.
